### PR TITLE
Fix regression regarding GIT binary patches

### DIFF
--- a/regression/t-070.out
+++ b/regression/t-070.out
@@ -294,3 +294,51 @@ HEAD is now at 8fd146e Featurize README
 Patch applied.
 % test -d sub
 % test abc jkl = abc jkl
+% guilt new binary
+% git checkout trunk
+Previous HEAD position was 8fd146e Featurize README
+Switched to branch "trunk"
+Your branch is up to date with 'origin/trunk'.
+% test abc def ghi = abc def ghi
+% git add somebinary .gitattributes
+% guilt ref
+Patch binary refreshed
+% guilt pop
+Submodule path 'sub': checked out '8fd146eb11cd2f931626fc70ee9e326a30dc5288'
+Now at use-feature.
+% test abc jkl = abc jkl
+% cat somebinary
+cat: somebinary: No such file or directory
+% guilt push
+Applying patch..binary
+Previous HEAD position was 8fd146e Featurize README
+HEAD is now at 6ddad03 Refine README
+[guilt/master cf77d1b] patch binary
+ Author: Author Name <author@email>
+ Date: Mon Jan 1 00:00:00 2007 +0000
+ 3 files changed, 2 insertions(+), 1 deletion(-)
+ create mode 100644 .gitattributes
+ create mode 100644 somebinary
+Patch applied.
+% test abc def ghi = abc def ghi
+% list_files
+d .git/patches
+d .git/patches/master
+f 47983ec5d6a525558c6c7ab031dfa14d7d039c2e  .git/patches/master/add-submodule
+f 98bf8b29e2c5ae1049cca9edcbc25d69e7acb4a3  .git/patches/master/update-sub
+f a4bcea8116a3ed6d5cd588051c2028e54443000d  .git/patches/master/local-changes
+f ad194509bf76d37b313bff5b7f7004b1e895000c  .git/patches/master/binary
+f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/add-submodule~
+f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/binary~
+f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/local-changes~
+f da39a3ee5e6b4b0d3255bfef95601890afd80709  .git/patches/master/update-sub~
+f fe34b55263c76b2b4f374f1aa293105cc42a9002  .git/patches/master/use-feature
+f fee28ca20cf7cb7b3e85a0e0fbdb5e480acba56d  .git/patches/master/series
+f fee28ca20cf7cb7b3e85a0e0fbdb5e480acba56d  .git/patches/master/status
+r 22853c81644b0c41d6fb5f372e4186281cf9ecea  .git/refs/patches/master/update-sub
+r 8b121046333c367b81bd566d4b3536ce7cb93bb3  .git/refs/patches/master/add-submodule
+r cf77d1bb3c45e0741a298debd4ea9f8289954963  .git/refs/patches/master/binary
+r fad0854bd2915f4b66cab5c08f05ad1ffa40665d  .git/refs/patches/master/use-feature
+r fbae6ca931b4c88f12fb694fbecace54c210ec95  .git/refs/patches/master/local-changes
+% cat somebinary
+hello

--- a/regression/t-070.sh
+++ b/regression/t-070.sh
@@ -196,3 +196,21 @@ shouldfail test -d sub
 cmd guilt push -a
 cmd test -d sub
 (cd sub && check_readme abc jkl)
+
+# Add a binary file and a change to the submodule, and check that we
+# can push and pop the patch.
+cmd guilt new binary
+echo hello > somebinary
+echo somebinary -diff > .gitattributes
+(cd sub && cmd git checkout trunk)
+(cd sub && check_readme abc def ghi)
+cmd git add somebinary .gitattributes
+cmd guilt ref
+cmd guilt pop
+fixup_time_info binary
+(cd sub && check_readme abc jkl)
+shouldfail cat somebinary
+cmd guilt push
+(cd sub && check_readme abc def ghi)
+cmd list_files
+cmd cat somebinary


### PR DESCRIPTION
Guilt already supports GIT binary patches (which are created if a file has a .gitattribute of -diff, for instance).  But the new extract-submodule.py helper didn't understand them, and would treat anything after a binary patch as a patch file footer.  This would cause it to miss submodule changes after such a patch.  When this happened, it would print the following message to stderr:

    warning: malformed patch, treated as footer.

This commit applies the changes from commit 6cb733dc5d9ac0 of the pdiffdiff repo to extract-submodule.py, thus adding support for GIT binary patches.  It also adds a test case to t-070.sh to ensure that binary patches work in Guilt.